### PR TITLE
Feat: get week summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@fastify/cors": "^9.0.1",
         "@paralleldrive/cuid2": "^2.2.2",
         "dayjs": "^1.11.13",
         "drizzle-orm": "^0.33.0",
@@ -1048,6 +1049,16 @@
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/cors": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-9.0.1.tgz",
+      "integrity": "sha512-YY9Ho3ovI+QHIL2hW+9X4XqQjXLjJqsU+sMV/xFsxZkE8p3GNnYVFpoOxF7SsP5ZL76gwvbo3V9L+FIekBGU4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "mnemonist": "0.39.6"
       }
     },
     "node_modules/@fastify/error": {
@@ -2205,6 +2216,12 @@
         "toad-cache": "^3.3.0"
       }
     },
+    "node_modules/fastify-plugin": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
+      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
+      "license": "MIT"
+    },
     "node_modules/fastify-type-provider-zod": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fastify-type-provider-zod/-/fastify-type-provider-zod-2.0.0.tgz",
@@ -2677,6 +2694,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
+      "integrity": "sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2728,6 +2754,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
+    "@fastify/cors": "^9.0.1",
     "@paralleldrive/cuid2": "^2.2.2",
     "dayjs": "^1.11.13",
     "drizzle-orm": "^0.33.0",

--- a/src/http/routes/get-week-summary.ts
+++ b/src/http/routes/get-week-summary.ts
@@ -1,0 +1,12 @@
+import { getWeekSummaryUseCase } from '../../use-cases/get-week-summary.useCase'
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+
+export const getWeekSummaryRoute: FastifyPluginAsyncZod = async app => {
+  app.get('/week-summary', async () => {
+    const { summary } = await getWeekSummaryUseCase()
+
+    return {
+      summary,
+    }
+  })
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -7,8 +7,14 @@ import {
 import { createGoalRoute } from './routes/create-goal'
 import { getPendingGoalsRoute } from './routes/get-pending-completions'
 import { createCompletionsRoute } from './routes/create-completion'
+import { getWeekSummaryRoute } from './routes/get-week-summary'
+import fastifyCors from '@fastify/cors'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
+
+app.register(fastifyCors, {
+  origin: '*',
+})
 
 app.setValidatorCompiler(validatorCompiler)
 app.setSerializerCompiler(serializerCompiler)
@@ -16,6 +22,7 @@ app.setSerializerCompiler(serializerCompiler)
 app.register(createGoalRoute)
 app.register(getPendingGoalsRoute)
 app.register(createCompletionsRoute)
+app.register(getWeekSummaryRoute)
 
 app
   .listen({

--- a/src/use-cases/get-week-summary.useCase.ts
+++ b/src/use-cases/get-week-summary.useCase.ts
@@ -1,0 +1,80 @@
+import dayjs from 'dayjs'
+import { db } from '../db'
+import { goalCompletions, goals } from '../db/schema'
+import { and, gte, lte, eq, sql } from 'drizzle-orm'
+//TODO:vvv-- estudar muito isso --vvv
+export async function getWeekSummaryUseCase() {
+  const lastDayOffWeek = dayjs().endOf('week').toDate()
+  const firstDayOffWeek = dayjs().startOf('week').toDate()
+
+  const goalsCreatedUpToWeek = db.$with('goals_created_up_to_week').as(
+    db
+      .select({
+        id: goals.id,
+        title: goals.title,
+        desiredWeeklyFrequency: goals.desiredWeeklyFrequency,
+        createdAt: goals.created_at,
+      })
+      .from(goals)
+      .where(lte(goals.created_at, lastDayOffWeek))
+  )
+
+  const goalsCompletedInWeek = db.$with('goals_completed_in_week').as(
+    db
+      .select({
+        id: goalCompletions.id,
+        title: goals.title,
+        completedAt: goalCompletions.createdAt,
+        completedAtDate: sql /*sql*/`
+          DATE(${goalCompletions.createdAt})`.as('completedAtDate'),
+      })
+      .from(goalCompletions)
+      .innerJoin(goals, eq(goals.id, goalCompletions.goalId))
+      .where(
+        and(
+          gte(goalCompletions.createdAt, firstDayOffWeek),
+          lte(goalCompletions.createdAt, lastDayOffWeek)
+        )
+      )
+  )
+
+  const goalsCompletedByWeekDay = db.$with('goals_completed_by_week_day').as(
+    db
+      .select({
+        completedAtDate: goalsCompletedInWeek.completedAtDate,
+        completions: sql /*sql*/`
+            JSON_AGG(
+              JSON_BUILD_OBJECT(
+                'id', ${goalsCompletedInWeek.id},
+                'title', ${goalsCreatedUpToWeek.title},
+                'completedAt', ${goalsCompletedInWeek.completedAt}
+              )
+            )
+          `.as('completions'),
+      })
+      .from(goalsCompletedInWeek)
+      .groupBy(goalsCompletedInWeek.completedAtDate)
+  )
+
+  const result = await db
+    .with(goalsCreatedUpToWeek, goalsCompletedInWeek, goalsCompletedByWeekDay)
+    .select({
+      completed: sql /*sql*/`
+        (SELECT COUNT(*) FROM ${goalsCompletedInWeek})
+      `.mapWith(Number),
+      total: sql /*sql*/`
+      (SELECT SUM(${goalsCreatedUpToWeek.desiredWeeklyFrequency}) FROM ${goalsCreatedUpToWeek})
+    `.mapWith(Number),
+      goalsPerDay: sql /*sql*/`
+      JSON_OBJECT_AGG(
+      ${goalsCompletedByWeekDay.completedAtDate},
+      ${goalsCompletedByWeekDay.completions}
+    )
+    `,
+    })
+    .from(goalsCompletedByWeekDay)
+
+  return {
+    summary: result,
+  }
+}

--- a/src/use-cases/list-pending-goals.useCase.ts
+++ b/src/use-cases/list-pending-goals.useCase.ts
@@ -3,7 +3,6 @@ import weekOfYear from 'dayjs/plugin/weekOfYear'
 import { db } from '../db'
 import { goalCompletions, goals } from '../db/schema'
 import { and, count, gte, lte, eq, sql } from 'drizzle-orm'
-import { number } from 'zod'
 
 dayjs.extend(weekOfYear)
 


### PR DESCRIPTION
## What was done:
- Register week summary route in server details
- Register Fastify Cors to our API
- Create a week summary use case to handle the function
- Create a route file to handle the Http GET Method called /week-summary, no params

## What expect:
- After calling the /week-summary Method GET with no params, it should return an object like the following:

<details>
<summary>Click to see the JSON response example</summary>

```json
{
    "summary": [
        {
            "completed": 4,
            "total": 19,
            "goalsPerDay": {
                "2024-09-10": [
                    {
                        "id": "e6be18evmvbgna6j98pdsopn",
                        "title": "Meditar",
                        "completedAt": "2024-09-10T22:53:06.962992+00:00"
                    },
                    {
                        "id": "fbwie49frbu6rzolin162obu",
                        "title": "Meditar",
                        "completedAt": "2024-09-10T22:52:43.740736+00:00"
                    }
                ],
                "2024-09-08": [
                    {
                        "id": "e89iclere1g1psghbnleza7f",
                        "title": "Acordar cedo",
                        "completedAt": "2024-09-08T03:00:00+00:00"
                    }
                ],
                "2024-09-09": [
                    {
                        "id": "vjbot8o4mukxujb0c6fs4420",
                        "title": "Me exercitar",
                        "completedAt": "2024-09-09T03:00:00+00:00"
                    }
                ]
            }
        }
    ]
}